### PR TITLE
Add to_json functionality to Point types

### DIFF
--- a/app/model.py
+++ b/app/model.py
@@ -1,13 +1,25 @@
 from datetime import datetime
-
+from flask import jsonify
 from . import db
-
 from geoalchemy2 import Geometry
 
 
-class Ping(db.Model):
-  __tablename__ = "ping"
+class Point(db.Model):
+  __tablename__ = "point"
   id = db.Column(db.Integer, primary_key=True)
   timestamp = db.Column(db.DateTime, index=True, default=datetime.utcnow())
   accuracy = db.Column(db.Float, default=100.0, nullable=False)
-  loc = db.Column(Geometry('POINT'))
+  geom = db.Column(Geometry(geometry_type='POINT'))
+
+  def to_json(self):
+      ''' Returns geojson representation of the point '''
+      latlon = self.geom.replace('POINT(','').replace(')','')
+      latlon = [float(n) for n in latlon.split(' ') ]
+      geom = {'type':'Point', 'coordinates':[latlon[0], latlon[1]] }
+      pt_json = {
+                    'id': self.id,
+                    'timestamp': self.timestamp,
+                    'accuracy': self.accuracy,
+                    'geometry': geom
+                }
+      return pt_json

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1,0 +1,42 @@
+import json
+import unittest
+from datetime import datetime
+
+from flask import current_app, url_for
+from app import create_app, db
+from app.model import Point
+
+import geoalchemy2.functions as func
+
+class ModelTestCase(unittest.TestCase):
+    def setUp(self):
+        self.app = create_app('testing')
+        self.app_context = self.app.app_context()
+        self.app_context.push()
+        db.create_all()
+        self.client = self.app.test_client()
+
+    def tearDown(self):
+        db.session.remove()
+        db.drop_all()
+        self.app_context.pop()
+
+    def test_point(self):
+        ''' Check point model '''
+        dt = datetime.utcnow()
+        lat = 41.836944
+        lon = -87.684722
+        point = Point(timestamp=dt,
+                      accuracy=25.0,
+                      geom='POINT({0} {1})'.format(lat, lon))
+
+        self.assertEqual(point.to_json()['id'], None )
+        self.assertEqual(point.to_json()['timestamp'], dt )
+        self.assertEqual(point.to_json()['accuracy'], 25.0 )
+        self.assertEqual(point.to_json()['geometry']['coordinates'], [lat,lon])
+
+        db.session.add(point)
+        self.assertEqual(Point.query.count(), 1)
+        # Make sure the postgis geojson matches object's to_json()
+        self.assertDictEqual(point.to_json()['geometry'],
+                    json.loads(db.session.scalar(func.ST_AsGeoJSON(point.geom))))


### PR DESCRIPTION
Allow points to return json with geom parameter that conforms to PostGIS geojson geometries.
